### PR TITLE
Use `systemctl [start|stop|restart]` when foreman_format is set to systemd

### DIFF
--- a/lib/mina/foreman/tasks.rb
+++ b/lib/mina/foreman/tasks.rb
@@ -4,6 +4,14 @@ set :foreman_log,  -> { "#{fetch(:deploy_to)}/#{fetch(:shared_path)}/log" }
 set :foreman_sudo, true
 set :foreman_format, 'upstart'
 set :foreman_location, '/etc/init'
+set :foreman_service, -> {
+  case fetch(:foreman_format)
+  when 'systemd'
+    "#{fetch(:foreman_app)}.target"
+  else
+    fetch(:foreman_app)
+  end
+}
 set :foreman_procfile, 'Procfile'
 
 namespace :foreman do
@@ -20,25 +28,37 @@ namespace :foreman do
 
   desc "Start the application services"
   task :start do
-    command %{
-      echo "-----> Starting #{fetch(:foreman_app)} services"
-      #{echo_cmd %[sudo start #{fetch(:foreman_app)}]}
-    }
+    command %{echo "-----> Starting #{fetch(:foreman_app)} services"}
+
+    command echo_cmd case fetch(:foreman_format)
+                     when 'systemd'
+                       %[sudo systemctl start #{fetch(:foreman_service)}]
+                     else
+                       %[sudo start #{fetch(:foreman_service)}]
+                     end
   end
 
   desc "Stop the application services"
   task :stop do
-    command %{
-      echo "-----> Stopping #{fetch(:foreman_app)} services"
-      #{echo_cmd %[sudo stop #{fetch(:foreman_app)}]}
-    }
+    command %{echo "-----> Stopping #{fetch(:foreman_app)} services"}
+
+    command echo_cmd case fetch(:foreman_format)
+                     when 'systemd'
+                       %[sudo systemctl stop #{fetch(:foreman_service)}]
+                     else
+                       %[sudo stop #{fetch(:foreman_service)}]
+                     end
   end
 
   desc "Restart the application services"
   task :restart do
-    command %{
-      echo "-----> Restarting #{fetch(:foreman_app)} services"
-      #{echo_cmd %[sudo start #{fetch(:foreman_app)} || sudo restart #{fetch(:foreman_app)}]}
-    }
+    command %{echo "-----> Restarting #{fetch(:foreman_app)} services"}
+
+    command echo_cmd case fetch(:foreman_format)
+                     when 'systemd'
+                       %[sudo systemctl restart #{fetch(:foreman_service)}]
+                     else
+                       %[sudo start #{fetch(:foreman_service)} || sudo restart #{fetch(:foreman_service)}]
+                     end
   end
 end


### PR DESCRIPTION
Attempted to add systemd support (aka `systemctl [start|stop|restart]`).
